### PR TITLE
Update buildpack to add the pdftopng (4.0.2) binary

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -7,8 +7,15 @@ ENVSCRIPT=$BUILD_DIR/.profile.d/xpdf.sh
 
 XPDF_DIR=${HOME}/vendor/xpdf
 
+echo "Adding XPDF tools.."
+echo "Creating install directory at $INSTALL_DIR..."
 mkdir -p $INSTALL_DIR
+
+echo "Unpacking XPDF binaries to $INSTALL_DIR..."
 tar -zxf xpdf.tar.gz -C $INSTALL_DIR
+
+copied=$(ls -l $INSTALL_DIR | awk '{print $9}')
+echo "Copied files: $copied"
 
 echo "Building runtime environment for xpdf into ${XPDF_DIR}"
 mkdir -p $BUILD_DIR/.profile.d

--- a/bin/compile
+++ b/bin/compile
@@ -14,7 +14,7 @@ mkdir -p $INSTALL_DIR
 echo "Unpacking XPDF binaries to $INSTALL_DIR..."
 tar -zxf xpdf.tar.gz -C $INSTALL_DIR
 
-copied=$(ls -l $INSTALL_DIR | awk '{print $9}')
+copied=$(ls -l $INSTALL_DIR | awk '{print $9}' ORS=" ")
 echo "Copied files: $copied"
 
 echo "Building runtime environment for xpdf into ${XPDF_DIR}"


### PR DESCRIPTION
Adds `pdftopng` version 4.0.2 (suffixed with a `4` to reflect the difference in version). Used by `PdfToImage` controller in the Vetcove app.

Binaries included
- pdfdetach (3.0.3)
- pdffonts (3.0.3)
- pdfimages (3.0.3)
- pdfinfo (3.0.3)
- pdftops (3.0.3)
- pdftotext (3.0.3)
- pdftopng4 (4.0.2)

Tagging @jon-torodash for a little look.